### PR TITLE
Add a link to a REST API description language comparison article

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,6 +131,7 @@ layout: default
                 <div class='timeline-footer'>
                   <ul>
                     <li><a href="https://en.wikipedia.org/wiki/Overview_of_RESTful_API_Description_Languages">Overview of RESTful API Description Languages</a></li>
+					<li><a href="http://modeling-languages.com/modeling-web-api-comparing/">Modeling Web APIs: your best choices</a> (sisältää kivan vertailutaulukon)</li>
                     <p>Valmistautumiseen menee arviolta 2-3 tuntia.</p>
                   </ul>
                 </div>


### PR DESCRIPTION
The article compares RAML, API Blueprint and Swagger (OpenAPI) and
includes a nice comparison table. Though not everything in the table
was clear to me I think it offers a good overview.
